### PR TITLE
feature/manage-goals-api-routes

### DIFF
--- a/lib/plausible/goal/schema.ex
+++ b/lib/plausible/goal/schema.ex
@@ -2,6 +2,7 @@ defmodule Plausible.Goal do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @derive {Jason.Encoder, only: [:domain, :event_name, :page_path]}
   schema "goals" do
     field :domain, :string
     field :event_name, :string

--- a/lib/plausible_web/router.ex
+++ b/lib/plausible_web/router.ex
@@ -88,6 +88,7 @@ defmodule PlausibleWeb.Router do
     post "/", ExternalSitesController, :create_site
     delete "/:site_id", ExternalSitesController, :delete_site
     put "/shared-links", ExternalSitesController, :find_or_create_shared_link
+    put "/goals", ExternalSitesController, :find_or_create_goal
   end
 
   scope "/api", PlausibleWeb do


### PR DESCRIPTION
### Changes

Adding api route `PUT /api/v1/sites/goals` with form fields `goal_type` and `goal_value` with supported types `event` and `page`

### Tests
- [ ] Automated tests have been added
- [ ] This PR does not require tests

### Changelog
- [ ] Entry has been added to changelog
- [x] This PR does not make a user-facing change

### Documentation
- [ ] [Docs](https://github.com/plausible/docs) have been updated
- [ ] This change does not need a documentation update
